### PR TITLE
Updated the code to support Video2Video lip sync video generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,38 @@
 
 
 ## 🔥 News
+
+I have added the code to support video2video lip sync. Now with this code user can pass input video and audio and do the lip sync.
+
+Changes are in -
+        modified:   flash_talk/configs/infer_params.yaml
+        modified:   flash_talk/inference.py
+        modified:   flash_talk/infinite_talk/utils/multitalk_utils.py
+        modified:   flash_talk/src/pipeline/flash_talk_pipeline.py
+        modified:   generate_video.py
+
+How to use the video2video inference
+
+CUDA_VISIBLE_DEVICES=0
+
+CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES python generate_video.py \
+    --ckpt_dir models/SoulX-FlashTalk-14B \
+    --wav2vec_dir models/chinese-wav2vec2-base \
+    --input_prompt "A person is talking. Only the foreground characters are moving, the background remains static." \
+    --cond_video examples/video.mp4 \
+    --audio_path examples/cantonese_16k.wav \
+    --audio_encode_mode stream
+
+just pass --cond_video examples/video.mp4 arg instead of --cond_image
+
+Both --cond_image, --cond_video would work with this code.
+
+flash_talk/configs/infer_params.yaml has different settings to generate HD/higher quality output which can be discarded, and default settings can be used to speed up the inference.
+
+Thanks
+
+
+
 - **2026.02.12** - We have released the [SoulX-FlashHead](https://github.com/Soul-AILab/SoulX-FlashHead), which is a streaming talking head project that achieves real-time performance on consumer GPUs (e.g., RTX 4090/5090).
 - **2026.01.08** - We have released the [inference code](https://github.com/Soul-AILab/SoulX-FlashTalk), and the [model weights](https://huggingface.co/Soul-AILab/SoulX-FlashTalk-14B).
 - **2025.12.30** - We released **Project page** on [SoulX-FlashTalk](https://soul-ailab.github.io/soulx-flashtalk/).

--- a/flash_talk/configs/infer_params.yaml
+++ b/flash_talk/configs/infer_params.yaml
@@ -2,9 +2,9 @@ frame_num: 33
 motion_frames_num: 5
 tgt_fps: 25
 sample_rate: 16000
-sample_steps: 4
-sample_shift: 5
-color_correction_strength: 1.0
+sample_steps: 12
+sample_shift: 3
+color_correction_strength: 0.7
 cached_audio_duration: 8
-height: 768
-width: 448
+height: 1024
+width: 576

--- a/flash_talk/inference.py
+++ b/flash_talk/inference.py
@@ -1,7 +1,11 @@
 # Copyright 2024-2025 The Alibaba Wan Team Authors. All rights reserved.
+import gc
+import os
 import yaml
 import torch
+from PIL import Image
 from loguru import logger
+from decord import VideoReader, cpu as decord_cpu
 
 from flash_talk.src.pipeline.flash_talk_pipeline import FlashTalkPipeline
 from flash_talk.src.distributed.usp_device import get_device, get_parallel_degree
@@ -67,4 +71,49 @@ def run_pipeline(pipeline, audio_embedding):
     sample = pipeline.generate(audio_embedding)
     sample_frames = (((sample+1)/2).permute(1,2,3,0).clip(0,1) * 255).contiguous()
     return sample_frames
+
+
+_VIDEO_EXTS = ('.mp4', '.avi', '.mov', '.mkv', '.flv', '.wmv', '.webm', '.mpeg', '.mpg')
+
+def extract_video_frame(video_path, frame_id):
+    """Extract a specific frame from a video file as a PIL Image.
+
+    If frame_id exceeds the video length, returns the last frame.
+    If the path points to an image file (not video), opens it directly.
+
+    Args:
+        video_path: Path to the video file.
+        frame_id: 0-based frame index to extract.
+
+    Returns:
+        PIL.Image in RGB mode.
+    """
+    ext = os.path.splitext(video_path)[1].lower()
+    if ext in _VIDEO_EXTS:
+        vr = VideoReader(video_path, ctx=decord_cpu(0))
+        if frame_id < len(vr):
+            frame = vr[frame_id].asnumpy()
+        else:
+            frame = vr[-1].asnumpy()
+        del vr
+        gc.collect()
+        frame = Image.fromarray(frame)
+    else:
+        frame = Image.open(video_path).convert("RGB")
+    return frame
+
+
+def update_cond_image(pipeline, video_path, frame_idx):
+    """Update the pipeline's conditioning image from a video frame.
+
+    Extracts the frame at frame_idx from video_path, then re-encodes it
+    with CLIP and VAE to update arg_c['clip_fea'] and arg_c['y'].
+
+    Args:
+        pipeline: FlashTalkPipeline instance.
+        video_path: Path to the source video.
+        frame_idx: Frame index to extract (0-based).
+    """
+    frame_image = extract_video_frame(video_path, frame_idx)
+    pipeline.update_cond_image(frame_image)
 

--- a/flash_talk/infinite_talk/utils/multitalk_utils.py
+++ b/flash_talk/infinite_talk/utils/multitalk_utils.py
@@ -662,12 +662,12 @@ def resize_and_centercrop(cond_image, target_size):
     if isinstance(cond_image, torch.Tensor):
         if len(cond_image.shape) == 3:
             cond_image = cond_image[None]
-        resized_tensor = nn.functional.interpolate(cond_image, size=(final_h, final_w), mode='nearest').contiguous() 
+        resized_tensor = nn.functional.interpolate(cond_image, size=(final_h, final_w), mode='bicubic', align_corners=False).contiguous()
         # crop
         cropped_tensor = transforms.functional.center_crop(resized_tensor, target_size) 
         cropped_tensor = cropped_tensor.squeeze(0)
     else:
-        resized_image = cond_image.resize((final_w, final_h), resample=Image.BILINEAR)
+        resized_image = cond_image.resize((final_w, final_h), resample=Image.LANCZOS)
         resized_image = np.array(resized_image)
         # tensor and crop
         resized_tensor = torch.from_numpy(resized_image)[None, ...].permute(0, 3, 1, 2).contiguous()

--- a/flash_talk/src/pipeline/flash_talk_pipeline.py
+++ b/flash_talk/src/pipeline/flash_talk_pipeline.py
@@ -248,6 +248,76 @@ class FlashTalkPipeline:
         return
 
     @torch.no_grad()
+    def update_cond_image(self, cond_image):
+        """Update the conditioning image for the next generation chunk.
+
+        Re-encodes the given image with CLIP and VAE, then updates
+        self.arg_c['clip_fea'] and self.arg_c['y']. This enables
+        per-chunk appearance anchoring when generating from a source video.
+
+        The color correction reference (self.original_color_reference) is
+        NOT updated -- it remains the first frame throughout.
+
+        Args:
+            cond_image: PIL.Image in RGB mode, or a file path string.
+        """
+        if isinstance(cond_image, str):
+            cond_image = Image.open(cond_image).convert("RGB")
+
+        cond_image_tensor = resize_and_centercrop(
+            cond_image, (self.target_h, self.target_w)
+        ).to(dtype=self.param_dtype, device=self.device)
+        cond_image_tensor = (cond_image_tensor / 255 - 0.5) * 2
+
+        self.cond_image_tensor = cond_image_tensor
+
+        # Re-encode with CLIP
+        if self.cpu_offload:
+            self.clip.model.to(self.device)
+        clip_context = self.clip.visual(
+            cond_image_tensor[:, :, -1:, :, :]
+        ).to(self.param_dtype)
+        if self.cpu_offload:
+            self.clip.model.cpu()
+            torch.cuda.empty_cache()
+
+        # Re-encode with VAE (zero-padded to frame_num + mask)
+        video_frames = torch.zeros(
+            1, cond_image_tensor.shape[1],
+            self.frame_num - cond_image_tensor.shape[2],
+            self.target_h, self.target_w
+        ).to(dtype=self.param_dtype, device=self.device)
+        padding_frames_pixels_values = torch.concat(
+            [cond_image_tensor, video_frames], dim=2
+        )
+
+        if self.cpu_offload:
+            self.vae.model.to(self.device)
+        y = self.vae.encode(padding_frames_pixels_values)
+        common_y = y.unsqueeze(0).to(self.param_dtype)
+
+        # Rebuild mask
+        msk = torch.ones(
+            1, self.frame_num, self.lat_h, self.lat_w, device=self.device
+        )
+        msk[:, 1:] = 0
+        msk = torch.concat([
+            torch.repeat_interleave(msk[:, 0:1], repeats=4, dim=1), msk[:, 1:]
+        ], dim=1)
+        msk = msk.view(1, msk.shape[1] // 4, 4, self.lat_h, self.lat_w)
+        msk = msk.transpose(1, 2).to(self.param_dtype)
+
+        y = torch.concat([msk, common_y], dim=1)
+
+        if self.cpu_offload:
+            self.vae.model.cpu()
+            torch.cuda.empty_cache()
+
+        # Update arg_c with fresh CLIP and VAE features
+        self.arg_c['clip_fea'] = clip_context
+        self.arg_c['y'] = y
+
+    @torch.no_grad()
     def preprocess_audio(self, speech_array, sr=16000, fps=25):
         audio_duration = len(speech_array) / sr
         video_length = audio_duration * fps

--- a/generate_video.py
+++ b/generate_video.py
@@ -13,12 +13,14 @@ from loguru import logger
 from collections import deque
 from datetime import datetime
 
-from flash_talk.inference import get_pipeline, get_base_data, get_audio_embedding, run_pipeline, infer_params
+from flash_talk.inference import get_pipeline, get_base_data, get_audio_embedding, run_pipeline, infer_params, extract_video_frame, update_cond_image
 
 def _validate_args(args):
     # Basic check
     assert args.ckpt_dir is not None, "Please specify FlashTalk model checkpoint directory."
     assert args.wav2vec_dir is not None, "Please specify the wav2vec checkpoint directory."
+    if args.cond_video is not None:
+        assert os.path.exists(args.cond_video), f"Condition video not found: {args.cond_video}"
 
     args.base_seed = args.base_seed if args.base_seed >= 0 else 9999
 
@@ -57,6 +59,13 @@ def _parse_args():
         default="examples/man.png",
         help="[meta file] The condition image path to generate the video.")
     parser.add_argument(
+        "--cond_video",
+        type=str,
+        default=None,
+        help="[optional] A source video path. When provided, each generation chunk "
+             "re-anchors appearance to the corresponding frame from this video. "
+             "Overrides --cond_image (frame 0 is used as initial conditioning).")
+    parser.add_argument(
         "--audio_path",
         type=str,
         default="examples/cantonese_16k.wav",
@@ -80,9 +89,10 @@ def _parse_args():
 def save_video(frames_list, video_path, audio_path, fps):
     temp_video_path = video_path.replace('res_', '')
     with imageio.get_writer(temp_video_path, format='mp4', mode='I',
-                            fps=fps , codec='h264', ffmpeg_params=['-bf', '0']) as writer:
+                            fps=fps, codec='libx264',
+                            ffmpeg_params=['-crf', '18', '-preset', 'slow', '-pix_fmt', 'yuv420p']) as writer:
         for frames in frames_list:
-            frames = frames.numpy().astype(np.uint8)
+            frames = np.round(frames.numpy()).clip(0, 255).astype(np.uint8)
             for i in range(frames.shape[0]):
                 frame = frames[i, :, :, :]
                 writer.append_data(frame)
@@ -105,7 +115,15 @@ def generate(args):
     rank = int(os.environ.get("RANK", 0))
 
     pipeline = get_pipeline(world_size=world_size, ckpt_dir=args.ckpt_dir, wav2vec_dir=args.wav2vec_dir, cpu_offload=args.cpu_offload)
-    get_base_data(pipeline, input_prompt=args.input_prompt, cond_image=args.cond_image, base_seed=args.base_seed)
+
+    # When a source video is provided, extract frame 0 as initial conditioning image
+    initial_cond_image = args.cond_image
+    if args.cond_video is not None:
+        initial_cond_image = extract_video_frame(args.cond_video, 0)
+        if rank == 0:
+            logger.info(f"Using video input: {args.cond_video} (frame 0 as initial conditioning)")
+
+    get_base_data(pipeline, input_prompt=args.input_prompt, cond_image=initial_cond_image, base_seed=args.base_seed)
 
     generated_list = []
     human_speech_array_all, _ = librosa.load(args.audio_path, sr=infer_params['sample_rate'], mono=True)
@@ -131,6 +149,11 @@ def generate(args):
                 logger.info(f"Generate video chunk-{chunk_idx} done, cost time: {(end_time - start_time):.2f}s")
 
             generated_list.append(video.cpu())
+
+            # Update conditioning image from source video for next chunk
+            if args.cond_video is not None:
+                next_frame_idx = (chunk_idx + 1) * slice_len
+                update_cond_image(pipeline, args.cond_video, next_frame_idx)
 
     elif args.audio_encode_mode == 'stream':
         cached_audio_length_sum = sample_rate * cached_audio_duration
@@ -160,6 +183,11 @@ def generate(args):
                 logger.info(f"Generate video chunk-{chunk_idx} done, cost time: {(end_time - start_time):.2f}s")
 
             generated_list.append(video.cpu())
+
+            # Update conditioning image from source video for next chunk
+            if args.cond_video is not None:
+                next_frame_idx = (chunk_idx + 1) * slice_len
+                update_cond_image(pipeline, args.cond_video, next_frame_idx)
 
 
     if rank == 0:


### PR DESCRIPTION
I have added the code to support video2video lip sync. Now with this code user can pass input video and audio and do the lip sync.

Changes are in -
        modified:   flash_talk/configs/infer_params.yaml
        modified:   flash_talk/inference.py
        modified:   flash_talk/infinite_talk/utils/multitalk_utils.py
        modified:   flash_talk/src/pipeline/flash_talk_pipeline.py
        modified:   generate_video.py

How to use the video2video inference

CUDA_VISIBLE_DEVICES=0

CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES python generate_video.py \
    --ckpt_dir models/SoulX-FlashTalk-14B \
    --wav2vec_dir models/chinese-wav2vec2-base \
    --input_prompt "A person is talking. Only the foreground characters are moving, the background remains static." \
    --cond_video examples/video.mp4 \
    --audio_path examples/cantonese_16k.wav \
    --audio_encode_mode stream

just pass --cond_video examples/video.mp4 arg instead of --cond_image

Both --cond_image, --cond_video would work with this code.

flash_talk/configs/infer_params.yaml has different settings to generate HD/higher quality output which can be discarded, and default settings can be used to speed up the inference.

Thanks

